### PR TITLE
#33 [Feat] 사용자 삭제 기능 구현

### DIFF
--- a/src/main/java/com/kreamify/domain/user/controller/UserController.java
+++ b/src/main/java/com/kreamify/domain/user/controller/UserController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 public class UserController {
     private final UserService userService;
+
     public UserController(UserService userService) {
         this.userService = userService;
     }
@@ -47,6 +48,13 @@ public class UserController {
     @GetMapping("/{id}")
     public  ResponseEntity<ApiResponse<UserResponse>> findUser(@PathVariable Long id) {
         return ResponseEntity.ok(ApiResponse.of(userService.findUser(id)));
+    }
+
+    //회원 삭제
+    @Operation(summary = "회원삭제",description = "회원 ID로 회원 삭제")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Long>> deleteUser(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.of(userService.deleteUser(id)));
     }
 
 

--- a/src/main/java/com/kreamify/domain/user/domain/User.java
+++ b/src/main/java/com/kreamify/domain/user/domain/User.java
@@ -118,9 +118,10 @@ public class User {
                     .orElseThrow(() -> new InvalidArgumentException(ErrorCode.INVALID_INPUT));
         }
 
-
-
-
+    }
+    //회원 삭제
+    public void deleteUser() {
+        this.isDeleted = true;
     }
 
 

--- a/src/main/java/com/kreamify/domain/user/service/UserService.java
+++ b/src/main/java/com/kreamify/domain/user/service/UserService.java
@@ -47,6 +47,15 @@ public class UserService {
         return findActiveUser(id).toResponse();
     }
 
+    //회원 삭제
+    @Transactional
+    public Long deleteUser(Long id){
+        User user = findActiveUser(id);
+        user.deleteUser();
+
+        return user.getId();
+
+    }
 
     @Transactional(readOnly = true)
     public User findActiveUser(Long id){
@@ -54,7 +63,6 @@ public class UserService {
                 .findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_RESOURCE));
     }
-
     //이미 존재하는 User 경우
     private void validateDuplicateUser(UserSignUpRequest userSignUpRequest) {
         if (userRepository.existsUserByEmail(
@@ -63,6 +71,7 @@ public class UserService {
             throw new DuplicateUserException(ErrorCode.CONFLICT_ERROR);
         }
     }
+
 
 
 


### PR DESCRIPTION
### 사용자 삭제 기능 구현
1. 사용자 조회 로직 분리 유지
- findUser(Long id)에서 findActiveUser(id)를 호출하여 삭제되지 않은 사용자만 조회
- findActiveUser(Long id)를 별도로 유지하여 재사용 가능 (예: 사용자 삭제 시에도 활용)
- 두 메서드를 합치면 코드가 간결해지지만, User 엔터티가 필요한 경우 재사용이 불가능
2. 논리적 삭제 구현 (is_deleted 필드 활용)
- 실제로 DB에서 데이터를 삭제하지 않고, is_deleted = true로 설정하여 삭제된 것처럼 처리
- 삭제된 사용자는 조회되지 않도록 findByIdAndIsDeletedFalse(id) 사용
3. 논리적 삭제의 문제점 및 개선 방향
- DB에는 삭제된 데이터가 그대로 남아 있어 데이터가 계속 쌓일 수 있음.
- 개선 방안: 삭제 시간을 기록하는 deleted_at 필드를 추가하고, 일정 시간이 지난 데이터는 DB에서 물리적으로 삭제하는 배치 작업을 수행해야할 것 같음