### PR TITLE
#41 [Test] 사용자 수정 및 탈퇴 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-
+	//lombok
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 
 
 }

--- a/src/main/java/com/kreamify/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/kreamify/domain/user/dto/UserResponse.java
@@ -1,7 +1,9 @@
 package com.kreamify.domain.user.dto;
 
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class UserResponse {
     private Long id;
     private String nickname;

--- a/src/test/java/com/kreamify/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kreamify/domain/user/controller/UserControllerTest.java
@@ -48,7 +48,7 @@ class UserControllerTest {
 
     @BeforeAll
     void setUp() throws Exception{
-        //첫번째 사용자
+        //첫번째 사용자(조회 데이터)
         UserSignUpTestRequest userSignUpRequest1 = new UserSignUpTestRequest(
                 "test1",
                 "test1@email.com",
@@ -61,7 +61,7 @@ class UserControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userSignUpRequest1))
         ).andExpect(status().isOk());
-        //두번째 사용자
+        //두번째 사용자(탈퇴 데이터)
         UserSignUpTestRequest userSignUpRequest2 = new UserSignUpTestRequest(
                 "test3",
                 "test3@test.com",
@@ -109,7 +109,7 @@ class UserControllerTest {
                 .andDo(print());
     }
 
-    @DisplayName("회원생성중복테스트")
+    @DisplayName("사용자 생성 중복테스트")
     @Test
     void saveUserMethodDuplicateExceptionTest() throws Exception {
         String nickname = "test1";
@@ -148,11 +148,11 @@ class UserControllerTest {
                 );
     }
 
-    @DisplayName("회원생성_예외_테스트")
+    @DisplayName("사용자 생성 형식과 다른 경우 예외 처리")
     @Test
     void saveUserMethodValidExceptionTest() throws Exception {
         String nickname = "test";
-        String email = "test";
+        String email = "test"; // 이메일 형식에 맞지 않게 기입했을 경우
         String phone = "01012341234";
         String size = "235";
         String address = "Seoul";
@@ -189,7 +189,7 @@ class UserControllerTest {
                 );
     }
 
-    @DisplayName("회원정보수정테스트")
+    @DisplayName("사용자 정보 수정 테스트")
     @Test
     void updateUserTest() throws Exception {
 
@@ -224,7 +224,7 @@ class UserControllerTest {
 
     }
 
-    @DisplayName("회원정보수정조회예외테스트")
+    @DisplayName("없는 사용자 조회하여 수정하려고 하는경우 예외처리")
     @Test
     void updateUserMethodNotFoundUserExceptionTest() throws Exception {
         Long userId = 3L;
@@ -262,12 +262,12 @@ class UserControllerTest {
                 );
     }
 
-    @DisplayName("회원정보수정옵션에러테스트")
+    @DisplayName("잘못된 항목 수정하는 경우 예외 처리")
     @Test
     void updateUserMethodInvalidOptionExceptionTest() throws Exception {
         Long userId = 1L;
         // given
-        String option = "Invalid Option";
+        String option = "Invalid Option"; // 존재하지 않는 옵션 선택
         String value = "updatedNickname";
 
         userUpdateTestRequest = new UserUpdateTestRequest(
@@ -300,7 +300,7 @@ class UserControllerTest {
                 );
     }
 
-    @DisplayName("회원조회_테스트")
+    @DisplayName("사용자 조회 테스트")
     @Test
     void findUserTest() throws Exception {
 
@@ -353,7 +353,7 @@ class UserControllerTest {
                 );
     }
 
-    @DisplayName("회원탈퇴_테스트")
+    @DisplayName("사용자 탈퇴 테스트")
     @Test
     void deleteUserTest() throws Exception {
         // given
@@ -382,7 +382,7 @@ class UserControllerTest {
     @Test
     void deleteUserMethodNotFoundExceptionTest() throws Exception {
         // given
-        Long userId = 3L; //2명의 사용자밖에 없기에 3번째 하면 에러
+        Long userId = 3L; //2명의 사용자밖에 없기에 3번 사용자를 하면 에러
 
         // when
         ResultActions result = mockMvc.perform(delete("/users/{id}", userId)

--- a/src/test/java/com/kreamify/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kreamify/domain/user/controller/UserControllerTest.java
@@ -3,10 +3,15 @@ package com.kreamify.domain.user.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kreamify.domain.config.TestConfig;
 import com.kreamify.domain.user.dto.UserSignUpTestRequest;
+import com.kreamify.domain.user.dto.UserUpdateTestRequest;
 import com.kreamify.domain.user.exception.DuplicateUserException;
+import com.kreamify.domain.user.exception.InvalidArgumentException;
+import com.kreamify.domain.user.exception.NotFoundUserException;
 import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,98 +21,388 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("local")
-@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
 @AutoConfigureMockMvc
 @TestConfig
-@Transactional
-public class UserControllerTest {
+@SpringBootTest
+class UserControllerTest {
+
+    private static UserSignUpTestRequest userSignUpRequest;
+    private static UserUpdateTestRequest userUpdateTestRequest;
 
     @Autowired
     private MockMvc mockMvc;
 
     @Autowired
     private ObjectMapper objectMapper;
+    
+    //사용자 두명 생성
+
+    @BeforeAll
+    void setUp() throws Exception{
+        //첫번째 사용자
+        UserSignUpTestRequest userSignUpRequest1 = new UserSignUpTestRequest(
+                "test1",
+                "test1@email.com",
+                "01012232324",
+                "235",
+                "Seoul"
+
+        );
+        mockMvc.perform(post("/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userSignUpRequest1))
+        ).andExpect(status().isOk());
+        //두번째 사용자
+        UserSignUpTestRequest userSignUpRequest2 = new UserSignUpTestRequest(
+                "test3",
+                "test3@test.com",
+                "01033334444",
+                "235",
+                "Busan"
+        );
+        mockMvc.perform(post("/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userSignUpRequest2))
+        ).andExpect(status().isOk());
+        // 현재 저장된 사용자 목록 확인
+        mockMvc.perform(get("/users")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
 
     @DisplayName("회원 가입 테스트")
     @Test
     void createUserTest() throws Exception {
-        // Given
-        UserSignUpTestRequest userSignUpRequest = new UserSignUpTestRequest(
-                "test",
-                "test@test.com",
-                "01012345678",
-                "235",
-                "Seoul"
+        // given
+        String nickname = "test";
+        String email = "test@email.com";
+        String phone = "01012341234";
+        String size = "235";
+        String address = "Seoul";
+
+        userSignUpRequest = new UserSignUpTestRequest(
+                nickname,
+                email,
+                phone,
+                size,
+                address
         );
 
-        // When
+        // when
         ResultActions result = mockMvc.perform(post("/users")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userSignUpRequest))
+                .content(objectMapper.writeValueAsString(userSignUpRequest)
+                )
         );
-
-        // Then
-        result.andExpect(status().isOk()).andDo(print());
-    }
-
-    @DisplayName("회원 생성 중복 테스트")
-    @Test
-    void saveUserDuplicate() throws Exception {
-        // Given (첫 번째 회원가입)
-        UserSignUpTestRequest userSignUpRequest = new UserSignUpTestRequest(
-                "test",
-                "test1@test.com",
-                "01012345678",
-                "235",
-                "Seoul"
-        );
-
-        mockMvc.perform(post("/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userSignUpRequest))
-        ).andExpect(status().isOk());
-
-        // When (중복 가입 시도)
-        ResultActions result = mockMvc.perform(post("/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userSignUpRequest))
-        );
-
-        // Then (중복 가입 예외 발생 검증)
-        result.andExpect(status().is4xxClientError())
-                .andExpect(res -> assertThrows(DuplicateUserException.class, () -> {
-                    throw res.getResolvedException();
-                })).andDo(print());
-    }
-    @DisplayName("회원 생성 예외 테스트")
-    @Test
-    void saveUserExceptionTest() throws Exception {
-        // Given(이메일 형식 오류)
-        UserSignUpTestRequest userSignUpRequest = new UserSignUpTestRequest(
-                "test",
-                "test",
-                "01012345678",
-                "235",
-                "Seoul"
-        );
-
-        // When
-        ResultActions result = mockMvc.perform(post("/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userSignUpRequest))
-        );
-
-        // Then
-        result.andExpect(status().is5xxServerError()).andExpect(res -> assertThrows(ConstraintViolationException.class,() -> {throw res.getResolvedException();}
-            )
-        )
+        // then
+        result
+                .andExpect(status().isOk())
                 .andDo(print());
     }
 
+    @DisplayName("회원생성중복테스트")
+    @Test
+    void saveUserMethodDuplicateExceptionTest() throws Exception {
+        String nickname = "test1";
+        String email = "test1@email.com";
+        String phone = "01012341234";
+        String size = "235";
+        String address = "Seoul";
+
+        userSignUpRequest = new UserSignUpTestRequest(
+                nickname,
+                email,
+                phone,
+                size,
+                address
+        );
+
+        //when(중복 가입 시도)
+        ResultActions result = mockMvc.perform(post("/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userSignUpRequest))
+        );
+
+        // then
+        result
+                .andExpect(
+                        status().is4xxClientError()
+                )
+                .andExpect(res -> assertTrue(res
+                                .getResolvedException()
+                                .getClass()
+                                .isAssignableFrom(DuplicateUserException.class)
+                        )
+                )
+                .andDo(
+                        print()
+                );
+    }
+
+    @DisplayName("회원생성_예외_테스트")
+    @Test
+    void saveUserMethodValidExceptionTest() throws Exception {
+        String nickname = "test";
+        String email = "test";
+        String phone = "01012341234";
+        String size = "235";
+        String address = "Seoul";
+
+        userSignUpRequest = new UserSignUpTestRequest(
+                nickname,
+                email,
+                phone,
+                size,
+                address
+        );
+
+        ResultActions result = mockMvc.perform(post("/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userSignUpRequest))
+        );
+
+        // then
+        result
+                .andExpect(//1. 회원가입 실패해서 서버오류
+                        status().is5xxServerError()
+                ) //2. 이메일 형식 에러
+                .andExpect(
+                        res -> assertTrue(
+                                res
+                                        .getResolvedException()
+                                        .getClass() //응답에서 발생한 오류 가져옴
+                                        .isAssignableFrom(ConstraintViolationException.class)
+                                // ConstraintViolationException: 이메일 형식 오류 , 값 누락 등으로 검증 실패할때 발생
+                        )
+                )
+                .andDo(
+                        print()
+                );
+    }
+
+    @DisplayName("회원정보수정테스트")
+    @Test
+    void updateUserTest() throws Exception {
+
+        Long userId = 2L;
+        // given
+        String option = "nickname";
+        String value = "test4";
+
+        userUpdateTestRequest = new UserUpdateTestRequest(
+                option,
+                value
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userUpdateTestRequest))
+        );
+
+        // then
+        result
+                .andExpect(
+                        status().isOk()
+                )
+                .andExpect(
+                        jsonPath("$.data").value(userId)
+                )
+                .andDo(
+                        print()
+
+                );
+
+    }
+
+    @DisplayName("회원정보수정조회예외테스트")
+    @Test
+    void updateUserMethodNotFoundUserExceptionTest() throws Exception {
+        Long userId = 3L;
+        // given
+        String option = "nickname";
+        String value = "test4";
+
+        userUpdateTestRequest = new UserUpdateTestRequest(
+                option,
+                value
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        userUpdateTestRequest)
+                )
+        );
+
+        // then
+        result
+                .andExpect(
+                        status().is4xxClientError()//클라리언트에러기대
+                )
+                .andExpect(
+                        res -> assertTrue(res
+                                .getResolvedException()
+                                .getClass()
+                                .isAssignableFrom(NotFoundUserException.class)
+                        )
+                )
+                .andDo(
+                        print()
+                );
+    }
+
+    @DisplayName("회원정보수정옵션에러테스트")
+    @Test
+    void updateUserMethodInvalidOptionExceptionTest() throws Exception {
+        Long userId = 2L;
+        // given
+        String option = "Invalid Option";
+        String value = "updatedNickname";
+
+        userUpdateTestRequest = new UserUpdateTestRequest(
+                option,
+                value
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                        userUpdateTestRequest)
+                )
+        );
+
+        // then
+        result
+                .andExpect(
+                        status().is4xxClientError()
+                )
+                .andExpect(
+                        res -> assertTrue(res
+                                .getResolvedException()
+                                .getClass()
+                                .isAssignableFrom(InvalidArgumentException.class)
+                        )
+                )
+                .andDo(
+                        print()
+                );
+    }
+
+    @DisplayName("회원조회_테스트")
+    @Test
+    void findUserTest() throws Exception {
+
+
+        // 2. 생성된 회원의 ID를 기반으로 조회 테스트(1번 데이터는 조회)
+        Long userId = 1L;
+
+        // when
+        ResultActions result = mockMvc.perform(get("/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").isNumber())
+                .andExpect(jsonPath("$.data.nickname").isString())
+                .andExpect(jsonPath("$.data.email").isString())
+                .andExpect(jsonPath("$.data.phone").isString())
+                .andExpect(jsonPath("$.data.size").isString())
+                .andExpect(jsonPath("$.data.address").isString())
+                .andDo(print());
+    }
+
+    @DisplayName("사용자 조회 실패:예외발생")
+    @Test
+    void findUserMethodNotFoundExceptionTest() throws Exception {
+        // given
+        Long userId = 3L; //2명의 사용자가 저장되어있으니깐 3번째 사용자 조회하면 에러
+
+        // when
+        ResultActions result = mockMvc.perform(get("/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result
+                .andExpect(
+                        status().is4xxClientError()
+                )
+                .andExpect(
+                        res -> assertTrue(res
+                                .getResolvedException()
+                                .getClass()
+                                .isAssignableFrom(NotFoundUserException.class)
+                        )
+                )
+                .andDo(
+                        print()
+                );
+    }
+
+    @DisplayName("회원탈퇴_테스트")
+    @Test
+    void deleteUserTest() throws Exception {
+        // given
+        Long userId = 2L;
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result
+                .andExpect(
+                        status().isOk()
+                )
+                .andExpect(
+                        jsonPath("$.data")
+                                .value(userId)
+                )
+                .andDo(
+                        print()
+                );
+    }
+
+    @DisplayName("존재하지않는 사용자를 삭제하려고 할때 에러 처리")
+    @Test
+    void deleteUserMethodNotFoundExceptionTest() throws Exception {
+        // given
+        Long userId = 3L; //2명의 사용자밖에 없기에 3번째 하면 에러
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result
+                .andExpect(
+                        status().is4xxClientError()
+                )
+                .andExpect(
+                        res -> assertTrue(res
+                                .getResolvedException()
+                                .getClass()
+                                .isAssignableFrom(NotFoundUserException.class)
+                        )
+                )
+                .andDo(
+                        print()
+                );
+    }
 }

--- a/src/test/java/com/kreamify/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kreamify/domain/user/controller/UserControllerTest.java
@@ -193,7 +193,7 @@ class UserControllerTest {
     @Test
     void updateUserTest() throws Exception {
 
-        Long userId = 2L;
+        Long userId = 1L;
         // given
         String option = "nickname";
         String value = "test4";
@@ -265,7 +265,7 @@ class UserControllerTest {
     @DisplayName("회원정보수정옵션에러테스트")
     @Test
     void updateUserMethodInvalidOptionExceptionTest() throws Exception {
-        Long userId = 2L;
+        Long userId = 1L;
         // given
         String option = "Invalid Option";
         String value = "updatedNickname";

--- a/src/test/java/com/kreamify/domain/user/dto/UserSignUpTestRequest.java
+++ b/src/test/java/com/kreamify/domain/user/dto/UserSignUpTestRequest.java
@@ -1,11 +1,18 @@
 package com.kreamify.domain.user.dto;
 
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class UserSignUpTestRequest {
+
     private String nickname;
     private String email;
     private String phone;
     private String size;
     private String address;
+    private Boolean isDeleted = false;
 
     public UserSignUpTestRequest(String nickname, String email, String phone, String size, String address) {
         this.nickname = nickname;
@@ -13,37 +20,6 @@ public class UserSignUpTestRequest {
         this.phone = phone;
         this.size = size;
         this.address = address;
-
+        //this.isDeleted = false; // 기본값 설정
     }
-    public String getNickname() {
-        return nickname;
-    }
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-    public String getEmail() {
-        return email;
-    }
-    public void setEmail(String email) {
-        this.email = email;
-    }
-    public String getPhone() {
-        return phone;
-    }
-    public void setPhone(String phone) {
-        this.phone = phone;
-    }
-    public String getSize() {
-        return size;
-    }
-    public void setSize(String size) {
-        this.size = size;
-    }
-    public String getAddress() {
-        return address;
-    }
-    public void setAddress(String address) {
-        this.address = address;
-    }
-
 }

--- a/src/test/java/com/kreamify/domain/user/dto/UserUpdateTestRequest.java
+++ b/src/test/java/com/kreamify/domain/user/dto/UserUpdateTestRequest.java
@@ -1,0 +1,16 @@
+package com.kreamify.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateTestRequest {
+    private String option;
+    private String value;
+
+}


### PR DESCRIPTION
### 변경사항

- Lombok의 @Getter, @Setter를 사용하여 DTO 클래스의 코드 간결화.
- Lombok을 사용하기 위해 build.gradle에 의존성 추가 
```

	//lombok
	testCompileOnly 'org.projectlombok:lombok'
	testAnnotationProcessor 'org.projectlombok:lombok'
```

- @BeforeAll을 사용하여 테스트 전에 사용자 데이터를 2개 생성 
- 첫 번째 사용자 → 사용자 조회 테스트용.
- 두 번째 사용자 → 삭제 테스트용 (탈퇴 처리와 조회 데이터 분리).
  
### 테스트 결과 및 테스트 코드 설명
- 조회, 수정 및 탈퇴 테스트 
- 존재하지않는 사용자를 조회하거나 존재하지않는 사용자에 대한 데이터를 수정할 경우와 탈퇴하는 경우에는 NotFoundUserException 발생하여 4** 에러를 발생하도록 예외 처리 
- 이메일 형식이 다르게 기입할 경우 ConstraintViolationException 5**에러를 발생하도록 예외 처리 
- 사용자가 중복으로 가입되어 있는 경우는 이메일 주소가 같은 사용자가 있으면 중복으로 가입되어 있다고 판별하도록 설계.