### PR TITLE
#57 [Feat] 구매 입찰 취소 기능 구현

### DIFF
--- a/src/main/java/com/kreamify/domain/deal/domain/BuyingBid.java
+++ b/src/main/java/com/kreamify/domain/deal/domain/BuyingBid.java
@@ -65,6 +65,11 @@ public class BuyingBid extends BaseEntity {
         this.status = status.getStatus();
 
     }
+
+    public void cancel() {
+        this.status = DealStatus.BID_CANCELED.getStatus();
+    }
+
     public String getConvertCreatedDate() {
         return getCreatedDate().format(DateTimeFormatter.ofPattern("yy/MM/dd"));
     }

--- a/src/main/java/com/kreamify/domain/deal/model/DealStatus.java
+++ b/src/main/java/com/kreamify/domain/deal/model/DealStatus.java
@@ -7,6 +7,7 @@ public enum DealStatus {
 
     BIDDING("입찰중"),
     EXPIRED("기한 만료"),
+    BID_CANCELED("입찰 취소"),
     BID_COMPLETED("입찰 완료"),
     UNDER_INSPECTION("검수 중"),
     SHIP_COMPLETED("배송 완료"),

--- a/src/main/java/com/kreamify/domain/deal/service/BuyingService.java
+++ b/src/main/java/com/kreamify/domain/deal/service/BuyingService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -138,6 +139,35 @@ public class BuyingService {
         }
 
         return buyingBids;
+    }
+
+    @Transactional
+    public void cancelBuyingBid(Long userId, Long bidId) {
+        BuyingBid buyingBid = buyingRepository
+                .findByIdAndUserAndStatus(
+                        bidId,
+                        userService.findActiveUser(userId),
+                        DealStatus.BIDDING.getStatus()
+                )
+                .orElseThrow(() -> new NotFoundBidException(ErrorCode.NOT_FOUND_RESOURCE));
+        buyingBid.cancel();
+
+        ProductOption productOption = productService.findProductOptionByProductIdAndSize(
+                buyingBid.getProduct().getId(), buyingBid.getSize()
+        );
+
+        // 입찰 취소 후 남아있는 입찰 중 최고 가격의 입찰을 찾아 업데이트
+        Optional<BuyingBid> topPriceBid = buyingRepository
+                .findFirstByProductAndSizeAndStatusOrderBySuggestPriceDesc(
+                        buyingBid.getProduct(),
+                        buyingBid.getSize(),
+                        DealStatus.BIDDING.getStatus()
+                );
+
+        // 최고 입찰(topPriceBid)이 존재하면 해당 가격으로 업데이트, 없는 경우 0으로 설정
+        productOption.updateBuyBidPrice(
+                topPriceBid.map(BuyingBid::getSuggestPrice).orElse(VALUE_ZERO)
+        );
     }
 
 }

--- a/src/main/java/com/kreamify/domain/user/controller/UserShoppingInfoController.java
+++ b/src/main/java/com/kreamify/domain/user/controller/UserShoppingInfoController.java
@@ -7,6 +7,7 @@ import com.kreamify.domain.deal.service.DealService;
 import com.kreamify.domain.deal.service.SellingService;
 import com.kreamify.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,14 +25,25 @@ public class UserShoppingInfoController {
             BuyingService buyingService,
             SellingService sellingService,
             DealService dealService
-    ){
+    ) {
         this.buyingService = buyingService;
         this.sellingService = sellingService;
         this.dealService = dealService;
     }
 
+    @Operation(summary = "구매 입찰 취소 API", description = "사용자가 구매 입찰 내역 중 특정 구매 입찰을 취소합니다.")
+    @DeleteMapping("/buying/{bidId}")
+    public ResponseEntity<Void> cancelBuyingBid(
+            @PathVariable Long userId,
+            @PathVariable Long bidId
+    ) {
+        buyingService.cancelBuyingBid(userId, bidId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
     @Operation(summary = "구매 입찰 내역 조회", description = "사용자의 ID와 상태 값(선택)을 이용해 구매 입찰 내역을 조회합니다.")
     @GetMapping("/buying/bidding")
+
     public ResponseEntity<ApiResponse<List<BuyingBidResponse>>> getBiddingHistory(
             @PathVariable Long userId,
             @RequestParam Optional<String> status
@@ -39,13 +51,14 @@ public class UserShoppingInfoController {
         return ResponseEntity.ok(
                 ApiResponse.of(
                         status
-                                .map(bidStatus -> buyingService.getBiddingHistoryByStatus(userId,bidStatus))
+                                .map(bidStatus -> buyingService.getBiddingHistoryByStatus(userId, bidStatus))
                                 .orElse(buyingService.getAllBiddingHistory(userId))
                 )
         );
 
     }
-    @Operation(summary = "구매 거래 진행 중 내역 조회 API",  description = "구매 입찰 거래가 체결되어 거래 진행 중인 내역을 조회합니다.")
+
+    @Operation(summary = "구매 거래 진행 중 내역 조회 API", description = "구매 입찰 거래가 체결되어 거래 진행 중인 내역을 조회합니다.")
     @GetMapping("/buying/pending")
     public ResponseEntity<ApiResponse<List<DealHistoryResponse>>> getPendingDealHistory(
             @PathVariable Long userId,
@@ -60,7 +73,8 @@ public class UserShoppingInfoController {
         );
 
     }
-    @Operation(summary = "구매 거래 종료 내역 조회 API", description ="거래가 종료된 내역을 조회합니다.")
+
+    @Operation(summary = "구매 거래 종료 내역 조회 API", description = "거래가 종료된 내역을 조회합니다.")
     @GetMapping("/buying/finished")
     public ResponseEntity<ApiResponse<List<DealHistoryResponse>>> getFinishedDealHistory(
             @PathVariable Long userId,

--- a/src/main/java/com/kreamify/domain/user/service/UserService.java
+++ b/src/main/java/com/kreamify/domain/user/service/UserService.java
@@ -56,6 +56,7 @@ public class UserService {
 
     }
 
+    @Transactional(readOnly = true)
     public User findActiveUser(Long id){
         return userRepository
                 .findByIdAndIsDeletedFalse(id)


### PR DESCRIPTION
- DealStatus Enum 수정 (입찰 취소 상태 추가)
- 사용자의 입찰 정보를 조회하고 ‘입찰 취소’ 상태로 변경하는 기능 추가
- 해당 입찰이 즉시 판매가(최고가)인 경우를 고려
- 기존 입찰을 취소하면, 같은 상품과 사이즈를 가진 최고 입찰가를 다시 조회
    즉, 현재 취소하는 입찰이 최고가였다면, 다음 최고 입찰가로 갱신