### PR TITLE
#66 [Fix] 구매 관련 기능 API 리펙토링

### DIFF
--- a/src/main/java/com/kreamify/domain/deal/domain/BuyingBid.java
+++ b/src/main/java/com/kreamify/domain/deal/domain/BuyingBid.java
@@ -76,9 +76,7 @@ public class BuyingBid extends BaseEntity {
         this.status = DealStatus.BID_CANCELED.getStatus();
     }
 
-    public String getConvertCreatedDate() {
-        return getCreatedDate().format(DateTimeFormatter.ofPattern("yy/MM/dd"));
-    }
+
 
     public String getExpiredDate() {
         return getCreatedDate()
@@ -101,7 +99,7 @@ public class BuyingBid extends BaseEntity {
         return new BidResponse(
                 suggestPrice,
                 deadline,
-                getConvertCreatedDate()
+                getExpiredDate()
         );
     }
 

--- a/src/main/java/com/kreamify/domain/deal/domain/BuyingBid.java
+++ b/src/main/java/com/kreamify/domain/deal/domain/BuyingBid.java
@@ -1,11 +1,12 @@
 package com.kreamify.domain.deal.domain;
 
 
+import com.kreamify.domain.deal.dto.BidResponse;
+import com.kreamify.domain.deal.dto.BuyingBidResponse;
 import com.kreamify.domain.deal.model.DealStatus;
 import com.kreamify.domain.product.domain.Product;
 import com.kreamify.domain.user.domain.User;
 import com.kreamify.global.domain.BaseEntity;
-import com.kreamify.domain.deal.dto.BuyingBidResponse;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -65,6 +66,11 @@ public class BuyingBid extends BaseEntity {
         this.status = status.getStatus();
 
     }
+    public void update(int price, int deadline) {
+        this.suggestPrice = price;
+        this.deadline = deadline;
+    }
+
 
     public void cancel() {
         this.status = DealStatus.BID_CANCELED.getStatus();
@@ -72,6 +78,12 @@ public class BuyingBid extends BaseEntity {
 
     public String getConvertCreatedDate() {
         return getCreatedDate().format(DateTimeFormatter.ofPattern("yy/MM/dd"));
+    }
+
+    public String getExpiredDate() {
+        return getCreatedDate()
+                .plusDays(deadline)
+                .format(DateTimeFormatter.ofPattern("yy/MM/dd"));
     }
 
     public BuyingBidResponse toResponse() {
@@ -82,6 +94,13 @@ public class BuyingBid extends BaseEntity {
                 size,
                 suggestPrice,
                 status,
+                getExpiredDate()
+        );
+    }
+    public BidResponse toBidResponse() {
+        return new BidResponse(
+                suggestPrice,
+                deadline,
                 getConvertCreatedDate()
         );
     }

--- a/src/main/java/com/kreamify/domain/deal/dto/BuyingBidResponse.java
+++ b/src/main/java/com/kreamify/domain/deal/dto/BuyingBidResponse.java
@@ -7,7 +7,7 @@ public record BuyingBidResponse (
     String size,
     int suggestPrice,
     String status,
-    String createdDate
+    String expiryDate
 ) {
 
 }


### PR DESCRIPTION
### 구매 관련 기능 API 리펙토링

1. 기존 구매 입찰 등록 방식 (문제점)
- 사용자가 같은 상품, 동일한 사이즈로 구매 입찰을 여러 번 등록하면 새로운 데이터가 계속 생성됨.
- 이 방식이면 중복 데이터가 DB에 쌓이고, 불필요한 데이터가 많아지는 문제가 발생.
- 따라서 같은 상품 + 같은 사이즈의 입찰이 있을 경우 기존 데이터 수정으로 변경.

