### PR TITLE
#75 [Fix] 완료된 체결 거래만 보여주기로 변경 

### DIFF
--- a/src/main/java/com/kreamify/domain/deal/dto/BuyingBidResponse.java
+++ b/src/main/java/com/kreamify/domain/deal/dto/BuyingBidResponse.java
@@ -7,7 +7,7 @@ public record BuyingBidResponse (
     String size,
     int suggestPrice,
     String status,
-    String expiryDate
+    String expiredDate
 ) {
 
 }

--- a/src/main/java/com/kreamify/domain/deal/repository/DealRepository.java
+++ b/src/main/java/com/kreamify/domain/deal/repository/DealRepository.java
@@ -10,11 +10,11 @@ import java.util.Optional;
 
 public interface DealRepository extends JpaRepository<Deal, Long> {
 
-    Optional<Deal> findFirstByProductOrderByCreatedDateDesc(Product product);
-    Optional<Deal> findFirstByProductAndSizeOrderByCreatedDateDesc(Product product, String size);
+    Optional<Deal> findFirstByProductAndIsFinishedTrueOrderByCreatedDateDesc(Product product);
+    Optional<Deal> findFirstByProductAndSizeAndIsFinishedTrueOrderByCreatedDateDesc(Product product, String size);
 
-    List<Deal> findAllByProductOrderByCreatedDateDesc(Product product);
-    List<Deal> findAllByProductAndSizeOrderByCreatedDateDesc(Product product, String size);
+    List<Deal> findAllByProductAndIsFinishedTrueOrderByCreatedDateDesc(Product product);
+    List<Deal> findAllByProductAndSizeAndIsFinishedTrueOrderByCreatedDateDesc(Product product, String size);
 
 
     List<Deal> findAllBySellerAndSellingStatusAndIsFinishedFalse(User user, String status);

--- a/src/main/java/com/kreamify/domain/product/service/ProductService.java
+++ b/src/main/java/com/kreamify/domain/product/service/ProductService.java
@@ -75,12 +75,12 @@ public class ProductService {
     public DetailResponse getProductDetail(Long id) {
         Product product = findActiveProduct(id);
 
-        Optional<Deal> optDeal = dealRepository.findFirstByProductOrderByCreatedDateDesc(product);
+        Optional<Deal> optDeal = dealRepository.findFirstByProductAndIsFinishedTrueOrderByCreatedDateDesc(product);
         int recentDealPrice = optDeal.isEmpty() ? NO_DEAL : optDeal
                 .get()
                 .getPrice();
 
-        List<Deal> dealPrices = dealRepository.findAllByProductOrderByCreatedDateDesc(product);
+        List<Deal> dealPrices = dealRepository.findAllByProductAndIsFinishedTrueOrderByCreatedDateDesc(product);
         List<BidDetail> buyingBids = buyingRepository.findAllByProductGroupBy(product.getId());
         List<BidDetail> sellingBids = sellingRepository.findAllByProductGroupBy(product.getId());
 
@@ -91,12 +91,12 @@ public class ProductService {
     public DetailResponse getProductDetailByOption(Long id, String size) {
         Product product = findActiveProduct(id);
 
-        Optional<Deal> optDeal = dealRepository.findFirstByProductAndSizeOrderByCreatedDateDesc(
+        Optional<Deal> optDeal = dealRepository.findFirstByProductAndSizeAndIsFinishedTrueOrderByCreatedDateDesc(
                 product, size);
         int recentDealPrice = optDeal.isEmpty() ? NO_DEAL : optDeal
                 .get()
                 .getPrice();
-        List<Deal> dealPrices = dealRepository.findAllByProductAndSizeOrderByCreatedDateDesc(
+        List<Deal> dealPrices = dealRepository.findAllByProductAndSizeAndIsFinishedTrueOrderByCreatedDateDesc(
                 product, size);
         List<BidDetail> buyingBids = buyingRepository.findAllByProductAndSizeGroupBy(
                 product.getId(), size);


### PR DESCRIPTION
기존 구현한 내용은 전체 체결 거래 내역을 보여주고 있어서 특정상품 상세조회에서 완료(거래, 배송까지)된 거래만 보여주는 것으로 리팩토링